### PR TITLE
[fix] WorkBookDomain : WorkBook 삭제 시 해당 멤버를 삭제시도 하는 버그 수정

### DIFF
--- a/src/main/java/com/buildup/nextQuestion/domain/WorkBook.java
+++ b/src/main/java/com/buildup/nextQuestion/domain/WorkBook.java
@@ -15,7 +15,7 @@ public class WorkBook {
     @Column(name = "work_book_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "member_id")
     private Member member;
 


### PR DESCRIPTION
workbook도메인에서 cascade.all을 통해 삭제 시 member 제거 하는 버그 수정을 위해 persist로 변경